### PR TITLE
Add gromacs gpu option

### DIFF
--- a/software-packages/gromacs.rst
+++ b/software-packages/gromacs.rst
@@ -20,10 +20,11 @@ Using GROMACS on Cirrus
 -----------------------
 
 GROMACS is Open Source software and is freely available to all Cirrus users.
-Four versions are available:
+A number of versions are available:
 
 * Serial/shared memory, single precision: gmx
 * Parallel MPI/OpenMP, single precision: gmx_mpi
+* GPU version, single precision: gmx
 
 Running parallel GROMACS jobs: pure MPI
 ---------------------------------------
@@ -92,3 +93,60 @@ total) and 6 OpenMP threads per MPI process.
    # Run using input in test_calc.tpr
    export OMP_NUM_THREADS=6
    mpiexec_mpt -ppn 6 -n 24 omplace -nt 6 gmx_mpi mdrun -s test_calc.tpr
+
+
+GROMACS GPU jobs
+----------------
+
+A separate build of GROMACS is provided to run on the NVIDIA GPU nodes
+on Cirrus (for details see :doc:`../user-guide/gpu`). Note also that
+the GPU version targets the GPU host nodes, which are Intel Skylake;
+this version will not run on the front end or the other non-GPU back-end nodes.
+
+The GPU version is accessed via, e.g.,
+
+::
+
+   module load gromacs-gpu/2020
+
+
+
+As there are currently a limited number of GPU nodes available, a
+distributed memory MPI version is not available: only the 'thread MPI'
+version is available (that is, 'gmx' is available, but not 'gmx_mpi').
+
+Further, we recommend exclusive node usage to prevent possible contention
+with other user jobs. An example of the form of the PBS submission script is:
+
+
+::
+
+   #!/bin/bash --login
+
+   #PBS -q gpu   
+   #PBS -N job-name
+   #PBS -l select=1:ncpus=40:ngpus=4
+   #PBS -l place=scatter:excl
+   #PBS -l walltime=00:20:00
+   
+   # Replace [budget code] below with your project code (e.g. t01)
+   #PBS -A [budget code]
+   
+   # Change to the directory that the job was submitted from
+   cd $PBS_O_WORKDIR
+   
+   # Load GROMACS GPU module
+
+   module load gromacs-gpu/2020
+
+   # Invocation will depend on problem type ...
+
+   export OMP_NUM_THREADS=10
+   gmx mdrun -ntmpi 4 -nb gpu -pme cpu ...
+
+
+Information on how to assign different types of calculation to the
+CPU or GPU appears in the GROMACS documentation under
+`Getting good performance from mdrun
+<http://manual.gromacs.org/documentation/current/user-guide/mdrun-performance.html>`__
+


### PR DESCRIPTION

I've added two modules:

gromacs/2020
gromacs-gpu/2020

with the first os as before and is described by the existing documentation.

The second is the separate gpu build which is described in the new section.

If you have any suggestions on this, please let me know an I can change it.